### PR TITLE
after master rejoined cluster deploy not running instances only

### DIFF
--- a/akkeeper/src/main/scala/akkeeper/master/service/MasterService.scala
+++ b/akkeeper/src/main/scala/akkeeper/master/service/MasterService.scala
@@ -19,7 +19,7 @@ import akka.actor._
 import akka.cluster.Cluster
 import akka.cluster.ClusterEvent.{InitialStateAsEvents, MemberUp}
 import akkeeper.api._
-import akkeeper.common.InstanceInfo
+import akkeeper.common.{InstanceId, InstanceInfo}
 import akkeeper.deploy.DeployClient
 import akkeeper.storage.InstanceStorage
 import akkeeper.utils.ConfigUtils._
@@ -41,6 +41,7 @@ private[akkeeper] class MasterService(deployClient: DeployClient.Async,
 
   private val seedInstances: mutable.Set[InstanceInfo] = mutable.Set.empty
   private var numOfRequiredInstances: Int = NumOfInstancesToJoin
+  private var initInstances: Seq[InstanceId] = Seq.empty
 
   override def preStart(): Unit = {
     context.watch(containerService)
@@ -60,9 +61,18 @@ private[akkeeper] class MasterService(deployClient: DeployClient.Async,
 
     context.become(initializedReceive)
     // Deploying instances specified in config.
-    val deployRequests = context.system.settings.config.getDeployRequests
-    log.debug(s"Deploying instances from config. " +
-      s"Number of deploy requests: ${deployRequests.size}")
+    var deployRequests = context.system.settings.config.getDeployRequests
+    val configuredInstanceCount  = deployRequests.map(_.quantity).sum
+    //remove current running instances from request
+    deployRequests = deployRequests.map{ container =>
+      val runningCount = initInstances.count(_.containerName == container.name)
+      container.copy(quantity = container.quantity - runningCount)
+    }.filter(_.quantity > 0)
+
+    log.debug(s"Deploying ${deployRequests.size} instances." +
+      s" Number of instances from config is $configuredInstanceCount," +
+      s" current running instance number is ${initInstances.size}")
+
     deployRequests.foreach(r => deployService ! r)
 
     unstashAll()
@@ -117,6 +127,7 @@ private[akkeeper] class MasterService(deployClient: DeployClient.Async,
 
   private def fetchInstancesListReceive: Receive = {
     case InstancesList(_, instances) =>
+      initInstances = instances
       if (instances.isEmpty) {
         log.info("No running instances were found. Creating a new Akka cluster")
         joinCluster(immutable.Seq(cluster.selfAddress))

--- a/akkeeper/src/test/scala/akkeeper/master/service/MasterServiceSpec.scala
+++ b/akkeeper/src/test/scala/akkeeper/master/service/MasterServiceSpec.scala
@@ -20,7 +20,7 @@ import akka.cluster.Cluster
 import akka.testkit.{ImplicitSender, TestKit}
 import akkeeper._
 import akkeeper.api._
-import akkeeper.common.InstanceId
+import akkeeper.common.{ContainerDefinition, InstanceId, InstanceUp}
 import akkeeper.deploy.{DeployClient, DeploySuccessful}
 import akkeeper.storage.InstanceStorage
 import com.typesafe.config.{Config, ConfigFactory, ConfigValueFactory}
@@ -138,6 +138,54 @@ class MasterServiceSpec extends FlatSpecLike with Matchers with MockFactory {
     }.run()
   }
 
+  it should "rejoin existing cluster without deploying running instances" in {
+    val instancesConfig = ConfigFactory
+      .parseString(
+        """
+          |akkeeper.instances = [
+          |  {
+          |    name = "container1"
+          |    quantity = 4
+          |  }
+          |]
+        """.stripMargin)
+      .withFallback(ConfigFactory.load("application-container-test.conf"))
+    new MasterServiceTestRunner(instancesConfig) {
+      override def test(): Unit = {
+        val selfAddr = Cluster(system).selfAddress
+        val instance = createInstanceInfo("container1")
+          .copy(address = Some(selfAddr), status = InstanceUp)
+        val storage = mock[InstanceStorage.Async]
+        (storage.start _).expects()
+        (storage.stop _).expects()
+        (storage.getInstances _).expects().returns(Future successful Seq(instance.instanceId))
+        (storage.getInstance _).expects(instance.instanceId).returns(Future successful instance)
+
+        val deployClient = mock[DeployClient.Async]
+
+        (deployClient.start _).expects()
+        (deployClient.deploy _)
+          .expects(new ArgThat[ContainerDefinition](container => container.name == "container1"),
+            new ArgThat[Seq[InstanceId]](ids => ids.size == 3))
+          .onCall { (_, instances) =>
+            Seq(Future.successful(DeploySuccessful(instances.head)))
+          }
+        (deployClient.stop _).expects()
+
+        val service = MasterService.createLocal(system, deployClient, storage)
+        awaitCond({
+          val getInstances = GetInstances()
+          service ! getInstances
+          val response = expectMsgClass(classOf[InstancesList])
+          response.requestId shouldBe getInstances.requestId
+          response.instanceIds.size ==  4
+        }, 10 seconds, 1 seconds, "failed to deploy new instance.")
+
+        gracefulActorStop(service)
+      }
+    }.run()
+  }
+
   it should "proxy deploy and container requests" in {
     val storage = mock[InstanceStorage.Async]
     (storage.start _).expects()
@@ -230,4 +278,5 @@ object MasterServiceSpec {
       system.shutdown()
     }
   }
+
 }


### PR DESCRIPTION
After application master rejoined existed cluster, it will re-submit all instances, which is not necessary.